### PR TITLE
If setting not found use the config, if config not found throw exception

### DIFF
--- a/src/Setting/SettingEloquentStorage.php
+++ b/src/Setting/SettingEloquentStorage.php
@@ -32,7 +32,19 @@ class SettingEloquentStorage implements SettingStorage
      */
     public function get($key, $default = null, $fresh = false)
     {
-        return $this->all($fresh)->get($key, $default);
+        $configValue = $this->all($fresh)->get($key, $default);
+
+        if (config('app_settings.allow_passthrough_config')) {
+            if (!$configValue) {
+                $configValue = config($key);
+                if (config('app_settings.exception_on_nodefined_config')) {
+                    if (is_null($configValue)) {
+                        throw new \Exception('Missing config value for ' . $key);
+                    }
+                }
+            }
+        }
+        return $configValue ;
     }
 
     /**


### PR DESCRIPTION
Allow getting of the config(key) when the settings(key) is not yet defined. Makes the app more transparant and all config() can be replaced by settings(). The code decides if the key can be overridden by the database, otherwise it just gets the config().
Also allow to throw an exception if the config() is not defined. This reduces typos in development