### PR TITLE
Add Laravel 7 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-  "name": "victoralagwu/laravel-settings",
-  "description": "Store key value pair in database as settings, (Just a little fix, the main author is qcod)",
-  "homepage": "https://github.com/victoralagwu/laravel-settings",
+  "name": "qcod/laravel-settings",
+  "description": "Store key value pair in database as settings",
+  "homepage": "https://github.com/qcod/laravel-settings",
   "type": "library",
   "license": "MIT",
   "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-  "name": "qcod/laravel-settings",
-  "description": "Store key value pair in database as settings",
-  "homepage": "https://github.com/qcod/laravel-settings",
+  "name": "victoralagwu/laravel-settings",
+  "description": "Store key value pair in database as settings, (Just a little fix, the main author is qcod)",
+  "homepage": "https://github.com/victoralagwu/laravel-settings",
   "type": "library",
   "license": "MIT",
   "keywords": [
@@ -23,8 +23,8 @@
   },
   "require-dev": {
     "orchestra/testbench": "~3.4|^4.0",
-    "mockery/mockery": "^0.9.4 || ~1.0",
-    "phpunit/phpunit": "^8.0"
+    "mockery/mockery": "^0.9.4 || ^1.3.1",
+    "phpunit/phpunit": "^8.5"
   },
   "autoload": {
     "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
   ],
   "require": {
     "php": "^7.2",
-    "laravel/framework": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0"
+    "laravel/framework": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0|6.*|7.*"
   },
   "require-dev": {
-    "orchestra/testbench": "~3.4|^4.0",
+    "orchestra/testbench": "3.8.*|4.*|5.*",
     "mockery/mockery": "^0.9.4 || ^1.3.1",
     "phpunit/phpunit": "^8.5"
   },

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
   ],
   "require": {
     "php": "^7.2",
-    "laravel/framework": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0"
+    "laravel/framework": "~5.4.0|~5.5.0|~5.6.0|~5.7.0|~5.8.0|^6.0|^7.0"
   },
   "require-dev": {
     "orchestra/testbench": "~3.4|^4.0",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-  "name": "qcod/laravel-settings",
-  "description": "Store key value pair in database as settings",
-  "homepage": "https://github.com/qcod/laravel-settings",
+  "name": "victoralagwu/laravel-settings",
+  "description": "Store key value pair in database as settings, (Just a little fix, the main author is qcod)",
+  "homepage": "https://github.com/victoralagwu/laravel-settings",
   "type": "library",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Laravel now has a version 7, This PR helps users to be able to use this package with Laravel 7